### PR TITLE
Modify/Neovim installation method

### DIFF
--- a/instapp/install_nvim.sh
+++ b/instapp/install_nvim.sh
@@ -3,9 +3,14 @@
 ####################
 # install Neovim
 ####################
-curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim.appimage # ref: https://github.com/neovim/neovim/wiki/Installing-Neovim#appimage-universal-linux-package
-chmod u+x nvim.appimage
-mv nvim.appimage /usr/local/bin/nvim
+curl -LO https://github.com/neovim/neovim/releases/download/stable/nvim-linux64.tar.gz
+
+tar -zxvf nvim-linux64.tar.gz
+mv nvim-linux64/bin/nvim /usr/bin/nvim
+mv nvim-linux64/lib/nvim /usr/lib/nvim
+mv nvim-linux64/share/nvim/ /usr/share/nvim
+rm -rf nvim-linux64
+rm nvim-linux64.tar.gz
 
 sudo apt-get install -y libfuse-dev
 

--- a/instapp/install_nvim.sh
+++ b/instapp/install_nvim.sh
@@ -5,7 +5,7 @@
 ####################
 curl -LO https://github.com/neovim/neovim/releases/download/stable/nvim-linux64.tar.gz
 
-tar -zxvf nvim-linux64.tar.gz
+tar -zxf nvim-linux64.tar.gz
 mv nvim-linux64/bin/nvim /usr/bin/nvim
 mv nvim-linux64/lib/nvim /usr/lib/nvim
 mv nvim-linux64/share/nvim/ /usr/share/nvim

--- a/instapp/install_nvim.sh
+++ b/instapp/install_nvim.sh
@@ -7,12 +7,12 @@ curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim.appimage
 chmod u+x nvim.appimage
 mv nvim.appimage /usr/local/bin/nvim
 
-sudo apt install libfuse-dev
+sudo apt-get install -y libfuse-dev
 
 ####################
 # install deno
 ####################
-sudo apt install unzip # unzip is needed by script to install deno.
+sudo apt-get install -y unzip # unzip is needed by script to install deno.
 
 curl -fsSL https://deno.land/x/install/install.sh | sh
 
@@ -23,7 +23,7 @@ ln -snfv ~/dotfiles/.profile ~/
 # install npm
 # Reference: https://www.softel.co.jp/blogs/tech/archives/6487
 ####################
-sudo apt -y install nodejs npm
+sudo apt-get -y install nodejs npm
 
 sudo npm install -g n
 sudo n stable

--- a/instapp/install_nvim.sh
+++ b/instapp/install_nvim.sh
@@ -32,8 +32,8 @@ sudo apt-get -y install nodejs npm
 
 sudo npm install -g n
 sudo n stable
-sudo apt purge -y nodejs npm
-sudo apt autoremove -y
+sudo apt-get purge -y nodejs npm
+sudo apt-get autoremove -y
 
 echo installed npm version: $(npm -v)
 echo installed node.js version: $(node -v)


### PR DESCRIPTION
# English
## Background
After creating an Ubuntu Docker container and installing these dotfiles, I encountered an issue where Neovim wouldn't start (error message below). 

## Error Message
```
fuse: device not found, try 'modprobe fuse' first

Cannot mount AppImage, please check your FUSE setup.
You might still be able to extract the contents of this AppImage 
if you run it with the --appimage-extract option. 
See https://github.com/AppImage/AppImageKit/wiki/FUSE 
for more information
open dir error: No such file or directory
```

# Modification
Given the issues potentially caused by using the appimage, I opted to use a different format for Neovim.

# 日本語（Original）
## 背景
UbuntuのDockerコンテナを作成した後にこのdotfilesをインストールしたところ、何故か起動できなかった（エラーメッセージは下記の通り）。そのため、利用するNeovimをappimage形式から、実行形式（と言うのかな？）を変更した。

### エラーメッセージ
```
fuse: device not found, try 'modprobe fuse' first

Cannot mount AppImage, please check your FUSE setup.
You might still be able to extract the contents of this AppImage 
if you run it with the --appimage-extract option. 
See https://github.com/AppImage/AppImageKit/wiki/FUSE 
for more information
open dir error: No such file or directory
```

## 修正
おそらくappimageを使っているのが問題だろうと考えたため、そうでない形式のnvimを利用することにした。